### PR TITLE
GLT-663 re-add Run QC metrics. NB: This will error out if no notification server is set up.

### DIFF
--- a/miso-web/src/main/resources/external/miso.properties
+++ b/miso-web/src/main/resources/external/miso.properties
@@ -67,7 +67,7 @@ miso.analysis.server.host:your.analysis.server
 miso.analysis.server.port:7898
 
 miso.notification.interop.enabled:true
-miso.notification.server.host:your.notification.server
+miso.notification.server.host:10.0.0.207
 miso.notification.server.port:8787
 
 ##config for the stats DB

--- a/miso-web/src/main/resources/external/miso.properties
+++ b/miso-web/src/main/resources/external/miso.properties
@@ -66,7 +66,7 @@ miso.taxonLookup.enabled:false
 miso.analysis.server.host:your.analysis.server
 miso.analysis.server.port:7898
 
-miso.notification.interop.enabled:false
+miso.notification.interop.enabled:true
 miso.notification.server.host:your.notification.server
 miso.notification.server.port:8787
 


### PR DESCRIPTION
The notification.server.host is pointed to Platinum, where the notification server is running (until at least Thursday). The port on Platinum is accessible, and I was able to view the Run QCs on my local server with these settings.
