### PR TITLE
added missing kit descriptor

### DIFF
--- a/sqlstore/src/main/resources/db/migration/V8015__add_kits.sql
+++ b/sqlstore/src/main/resources/db/migration/V8015__add_kits.sql
@@ -1,0 +1,8 @@
+INSERT INTO KitDescriptor(name, version, manufacturer, partNumber, stockLevel, kitType, platformType, description, lastModifier)
+SELECT 'KAPA OnBead', 0, 'KAPA', 1, 0, 'Library', 'Illumina', 'n/a', 1
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM KitDescriptor WHERE name = 'KAPA OnBead');
+
+INSERT INTO KitDescriptor(name, version, manufacturer, partNumber, stockLevel, kitType, platformType, description, lastModifier)
+VALUES ('CRISPR Seq Prep', 0, 'CRISPR', 1, 0, 'Library', 'Illumina', 'n/a', 1),
+('Nextera XT', 0, 'Nextera', 1, 0, 'Library', 'Illumina', 'n/a', 1);


### PR DESCRIPTION
Note: the `WHERE NOT EXISTS` is in-case _someone_ already sneaked the record into prod... :innocent: 
