### PR TITLE
correct delimiter in SVR migration

### DIFF
--- a/sqlstore/src/main/resources/db/migration/V8251__svrs_for_TGL.sql
+++ b/sqlstore/src/main/resources/db/migration/V8251__svrs_for_TGL.sql
@@ -1,6 +1,6 @@
 --StartNoTest
 DELIMITER //
-DROP PROCEDURE IF EXISTS insert_svr_if_not_exists;
+DROP PROCEDURE IF EXISTS insert_svr_if_not_exists//
 CREATE PROCEDURE insert_svr_if_not_exists(svrParentId BIGINT(20), svrChildId BIGINT(20))
 BEGIN
   SET @time = NOW();


### PR DESCRIPTION
So that migrating with Flyway doesn't fail.